### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,4 +1,6 @@
 ﻿name: build-and-deploy
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/alexi-courieux/alexi-courieux-resume/security/code-scanning/3](https://github.com/alexi-courieux/alexi-courieux-resume/security/code-scanning/3)

In general, the fix is to explicitly define `permissions` either at the workflow root (applies to all jobs) or within the specific job. This constrains the `GITHUB_TOKEN` used by actions like `actions/checkout` to the smallest required scope, typically `contents: read` for a simple build-and-deploy workflow that only needs to read the repo.

For this workflow, the safest non-breaking fix is to add a workflow-level `permissions` block immediately after the `name:` (or after `on:` if you prefer) that sets `contents: read`. None of the steps write to GitHub (no pushing commits, creating releases, manipulating issues, etc.), so `contents: read` is sufficient for checking out code. No additional methods, imports, or definitions are required; this is a pure YAML configuration change confined to `.github/workflows/build-deploy.yml`.

Concretely: edit `.github/workflows/build-deploy.yml` to insert:

```yaml
permissions:
  contents: read
```

right after the `name: build-and-deploy` line. This satisfies CodeQL’s requirement and enforces least privilege on `GITHUB_TOKEN` without altering existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
